### PR TITLE
feat: 增加顶部tab切换组件

### DIFF
--- a/src/component/ZydTabChange.vue
+++ b/src/component/ZydTabChange.vue
@@ -1,0 +1,73 @@
+<!-- 
+<ZydTabChange
+  :tabList="tabList"
+  //默认选中tab
+  :activeName="逆变器日报"
+  //不使用插槽则使用函数监控active变化
+  @activeChange="activeChange($event)"
+>
+  //根据tabList的name值，切换对应的内容
+  <template #daily>123</template>
+</ZydTabChange> 
+
+-->
+
+<template>
+  <el-tabs v-model="active">
+    <el-tab-pane v-for="(item, index) in tabList" :key="index" :label="item.label" :name="item.name">
+      <slot :name="item.name" v-if="active === item.name"></slot>
+    </el-tab-pane>
+  </el-tabs>
+</template>
+
+<script>
+export default {
+  name: 'zydtab',
+  props: {
+    tabList: {
+      type: Array,
+      default: () => [],
+    },
+    //默认tab
+    activeName: {
+      type: String,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      active: this.activeName || (this.tabList.length > 0 ? this.tabList[0].name : ''),
+    };
+  },
+  watch: {
+    //不使用插槽，根据activeName变化，触发activeChange事件
+    active(val) {
+      this.$emit('activeChange', val);
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+::v-deep {
+  .el-tabs__header {
+    width: 100%;
+    padding: 0 16px !important;
+  }
+  .el-tabs__item.is-active {
+      font-weight:600 !important;
+      color: #2355d8 !important;
+    }
+
+    .el-tabs__item {
+      height: 53px;
+      line-height: 53px;
+      padding: 0 24px 0 0 !important;
+      color: #666 !important;
+      font-weight: normal !important;
+    }
+
+    .el-tabs__nav-wrap::after {
+      height: 1px !important;
+    }
+}
+</style>


### PR DESCRIPTION
添加顶部tab切换组件
目的：统一样式，高度53px，未选中tab颜色#666，字重normal
tab列表格式为
[
  {
    name: 'first',
    label: '第一个',
  },
  {
    name: 'second',
    label: '第二个',
  },
]，

<ZydTabChange :tabList="tabList" @activeChange="activeChange($event)">
  <template #first>{{ activeName }}</template>
  <template #second>{{ activeName }}</template>
</ZydTabChange>

activeChange(name) {
  this.activeName = name;
  this.search();
},

![image](https://github.com/xiaobaili1992/zyd-design/assets/101035003/8d4eb684-f1e7-4905-a067-9878b406a89b)
![image](https://github.com/xiaobaili1992/zyd-design/assets/101035003/3f82f42a-6ad8-4738-9e90-a4615e51620b)
