### PR TITLE
feat: fix: Page组件表格添加默认排序方法，OperateBtn组件添加popover支持

### DIFF
--- a/src/component/ZydOperateBtn.vue
+++ b/src/component/ZydOperateBtn.vue
@@ -1,9 +1,14 @@
 <template>
   <div class="zyd-operate-btn">
     <span v-for="(item, index) in topThreeConfig" :key="item.key">
-      <el-button type="text" v-bind="item.attrs || {}" @click="(e) => commonFn(item, 'click', e)">
-        {{ item.label }}
-      </el-button>
+      <el-popover
+        :disabled="!item.tooltip"
+        :placement="item.tooltip?.placement||'top-start'"
+        :width="item.tooltip?.width||200"
+        :trigger="item.tooltip?.trigger||'hover'">
+        <slot :name="item.key"></slot>
+        <el-button type="text"  v-bind="item.attrs || {}" @click="(e) => commonFn(item, 'click', e)" slot="reference">{{ item.label }}</el-button>
+      </el-popover>
       <el-divider
         class="zyd-operate-vertical-line"
         direction="vertical"

--- a/src/component/ZydPage.vue
+++ b/src/component/ZydPage.vue
@@ -99,6 +99,7 @@
               style="width: 100%"
               max-width="100%"
               :data="tableConfig.dataSource || []"
+              :default-sort="tableConfig.defaultSort || {}"
               v-loading="tableConfig.loading"
               v-bind="tableConfig.attrs || {}"
               @select="

--- a/src/component/ZydPage.vue
+++ b/src/component/ZydPage.vue
@@ -210,7 +210,13 @@
                   image="https://dee-static.oss-cn-beijing.aliyuncs.com/dee-web/empty-data.png"
                 />
               </template>
-              <el-table-column
+
+                <el-table-column 
+                  v-if="tableConfig?.selection==true"
+                  type="selection" width="55"       
+                  :selectable="selectableRow">
+                </el-table-column>
+                <el-table-column
                 v-for="item in tableConfig.columns || []"
                 :prop="item.prop"
                 :label="item.label"
@@ -323,6 +329,9 @@ export default {
   },
   mounted() {},
   methods: {
+    selectableRow(row) {
+      return row?.selectable != false;
+    },
     commonFn(item, type, value) {
       item?.events?.[type]?.(value);
     },
@@ -453,6 +462,11 @@ export default {
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
+          }
+          ::v-deep .el-table-column--selection{
+            .cell{
+              padding-left: 14px;
+            }
           }
           ::v-deep {
             .el-table::before,


### PR DESCRIPTION
{
  label: '详情',
  key: 'detail',
  attrs: {},
  tooltip: {
    show: true,
    placement: 'top-start',//位置，不配默认top-start
    trigger: 'hover',//触发方式，不配默认hover
    width: 500,//宽度，不配默认200
  }, //配置添加tooltip属性
  events: {},
},

<ZydOperateBtn :key="refresh" :operateBtnConfig="getOperateBtnConfig(record)">
  <template #detail>一</template>//弹窗内容根据config的key进行slot
</ZydOperateBtn>

![image](https://github.com/xiaobaili1992/zyd-design/assets/101035003/688c0f49-f99f-4c98-a6c2-b7ccc7721b7f)

